### PR TITLE
Add new listener builder widget

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,7 @@ import './demo_page.dart';
 import './widgets/demo_1.dart';
 import './widgets/demo_2.dart';
 import './widgets/demo_3.dart';
+import './widgets/demo_4.dart';
 
 void main() => runApp(const MyApp());
 
@@ -37,6 +38,12 @@ class MyApp extends StatelessWidget {
                   navigate(context, const Demo3());
                 },
                 child: const Text('Demo 3'),
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  navigate(context, const Demo4());
+                },
+                child: const Text('Listener Demo'),
               ),
             ],
           );

--- a/example/lib/widgets/demo_4.dart
+++ b/example/lib/widgets/demo_4.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_offline/flutter_offline.dart';
+
+class Demo4 extends StatelessWidget {
+  const Demo4({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return OfflineListener(
+      debounceDuration: Duration.zero,
+      listenWhen: (c) => c == ConnectivityResult.mobile,
+      listenerBuilder: (context, connectivity) {
+        // for ex showing a snackbar when using mobile internet if app is downloading something big.
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+            content: Text(
+                'Alert: Switched to mobile internet, consider switching to wifi instead.')));
+      },
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: const <Widget>[
+            Text(
+              'There are no bottons to push :)',
+            ),
+            Text(
+              'Try switching your internet to wifi and mobile data',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/flutter_offline.dart
+++ b/lib/flutter_offline.dart
@@ -1,5 +1,7 @@
 library flutter_offline;
 
-export 'package:connectivity_plus/connectivity_plus.dart' show ConnectivityResult;
+export 'package:connectivity_plus/connectivity_plus.dart'
+    show ConnectivityResult;
 
 export 'src/main.dart';
+export 'src/offline_listener.dart';

--- a/lib/src/offline_listener.dart
+++ b/lib/src/offline_listener.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_offline/src/utils.dart';
+import 'package:network_info_plus/network_info_plus.dart';
+
+import 'main.dart';
+
+typedef ListenerBuilder<T> = void Function(BuildContext context, T value);
+typedef ListenWhen<T> = bool Function(ConnectivityResult);
+
+class OfflineListener extends StatefulWidget {
+  factory OfflineListener({
+    Key? key,
+    required Widget child,
+    ListenWhen? listenWhen,
+    Duration debounceDuration = kOfflineDebounceDuration,
+    ListenerBuilder<ConnectivityResult>? listenerBuilder,
+    WidgetBuilder? errorBuilder,
+  }) {
+    return OfflineListener.initialize(
+      key: key,
+      connectivityService: Connectivity(),
+      wifiInfo: NetworkInfo(),
+      debounceDuration: debounceDuration,
+      errorBuilder: errorBuilder,
+      listenWhen: listenWhen,
+      listenerBuilder: listenerBuilder,
+      child: child,
+    );
+  }
+
+  @visibleForTesting
+  const OfflineListener.initialize({
+    Key? key,
+    required this.connectivityService,
+    required this.wifiInfo,
+    required this.child,
+    this.listenWhen,
+    this.listenerBuilder,
+    this.debounceDuration = kOfflineDebounceDuration,
+    this.errorBuilder,
+  }) : super(key: key);
+
+  /// Override connectivity service used for testing
+  final Connectivity connectivityService;
+
+  /// Specify when to listen
+  final ListenWhen? listenWhen;
+
+  /// Listen to new updates on connectivity. Only notifies when listenWhen returns true.
+  ///
+  /// If listenWhen is null, will listen to all updates.
+  final ListenerBuilder<ConnectivityResult>? listenerBuilder;
+
+  final NetworkInfo wifiInfo;
+
+  /// Debounce duration from epileptic network situations
+  final Duration debounceDuration;
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  /// Used for building the error widget incase of any platform errors
+  final WidgetBuilder? errorBuilder;
+
+  @override
+  OfflineListenerState createState() => OfflineListenerState();
+}
+
+class OfflineListenerState extends State<OfflineListener> {
+  late Stream<ConnectivityResult> _connectivityStream;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _connectivityStream =
+        Stream.fromFuture(widget.connectivityService.checkConnectivity())
+            .asyncExpand((data) => widget
+                .connectivityService.onConnectivityChanged
+                .transform(startsWith(data)))
+            .transform(debounce(widget.debounceDuration));
+
+    _listenToChanges();
+  }
+
+  void _listenToChanges() {
+    _connectivityStream.listen((data) {
+      if (widget.listenWhen?.call(data) ?? true) {
+        widget.listenerBuilder?.call(context, data);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}
+
+class OfflineListenerError extends Error {
+  OfflineListenerError(this.error);
+
+  final Object error;
+
+  @override
+  String toString() => error.toString();
+}


### PR DESCRIPTION
## Problem statement
Was wandering around this package. I saw there's just a widget builder widget rebuilding the widgets on change of the connectivity. I think it should have a widget that will just give me a listener, as I don't want to rebuild the widgets but do some action against the change.

Eg.: I want to show the users an alert if they switch to mobile data to shift back to wifi (as for instance I am downloading big files or streaming high-quality content)

## Solution
I've implemented a new widget like that of the builder, but with a listenerBuilder property to just listen to changes and not rebuild the widgets. 

## Bonus
I've also added in `listenWhen` to only listen to specific changes. For more details, refer to the new demo page in the example.

## Video Sample

https://user-images.githubusercontent.com/47249618/183369736-c059dd38-c82e-42d1-b88c-f84b311251a1.mp4



